### PR TITLE
bug🐛: fix line break and line wrap

### DIFF
--- a/textbase/frontend/src/App.css
+++ b/textbase/frontend/src/App.css
@@ -3,6 +3,7 @@
   margin: 0 auto;
   padding: 2rem;
   text-align: center;
+  white-space: pre-wrap;
 }
 
 .logo {


### PR DESCRIPTION
## Description
add `white-space: pre-wrap;` to appropriately format the `\n` in the message content.

## Motivation and Context
The Output for ordered and unordered lists are not formatted as they should be, which makes it difficult to read the output. This PR aims to improve this behavior.

## Screenshots:
*Before*-
![image](https://github.com/cofactoryai/textbase/assets/77539004/27899e6d-884f-4a57-acd7-0e89d930cdc5)

*After*-
![image](https://github.com/cofactoryai/textbase/assets/77539004/c43d96e4-cca0-4c71-a22f-6a26c1f99519)

