### PR TITLE
Add support for Azure, Claude2, Llama2, Palm, Cohere, Replicate Models - using litellm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ langchain = "^0.0.239"
 fastapi = "*"
 uvicorn = "*"
 pydantic = "^1.9.9"
+litellm = "0.1.386"
 
 
 [build-system]

--- a/textbase/models.py
+++ b/textbase/models.py
@@ -1,5 +1,6 @@
 import json
 import openai
+from litellm import completion
 import requests
 import time
 import typing
@@ -22,7 +23,7 @@ class OpenAI:
         assert cls.api_key is not None, "OpenAI API key is not set"
         openai.api_key = cls.api_key
 
-        response = openai.ChatCompletion.create(
+        response = completion(
             model=model,
             messages=[
                 {"role": "system", "content": system_prompt},


### PR DESCRIPTION
This PR adds support for models from all the above mentioned providers using https://github.com/BerriAI/litellm/

Here's a sample of how it's used:

```
from litellm import completion, acompletion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# llama2 call
model_name = "replicate/llama-2-70b-chat:2c1608e18606fad2812020dc541930f2d0495ce32eee50074220b87300bc16e1"
response = completion(model_name, messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```