### PR TITLE
Integration with WhatsApp and SMS using Twilio API

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,11 +3,20 @@ from textbase.message import Message
 from textbase import models
 import os
 from typing import List
+from twilio.twiml.messaging_response import MessagingResponse
+from flask import Flask, request
 
 # Load your OpenAI API key
 models.OpenAI.api_key = "YOUR_API_KEY"
 # or from environment variable:
 # models.OpenAI.api_key = os.getenv("OPENAI_API_KEY")
+
+# Twilio credentials
+TWILIO_ACCOUNT_SID = "YOUR_TWILIO_ACCOUNT_SID"
+TWILIO_AUTH_TOKEN = "YOUR_TWILIO_AUTH_TOKEN"
+TWILIO_PHONE_NUMBER = "YOUR_TWILIO_PHONE_NUMBER"  # Your Twilio phone number
+
+app = Flask(__name__)
 
 # Prompt for GPT-3.5 Turbo
 SYSTEM_PROMPT = """You are chatting with an AI. There are no specific prefixes for responses, so you can ask or talk about anything you like. The AI will respond in a natural, conversational manner. Feel free to start the conversation with any question or topic, and let's have a pleasant chat!
@@ -36,3 +45,26 @@ def on_message(message_history: List[Message], state: dict = None):
     )
 
     return bot_response, state
+
+@app.route('/webhook', methods=['POST'])
+def handle_webhook():
+    incoming_message = request.form.get('Body', '').lower()
+    response, state = on_message([Message(content=incoming_message)], state=None)
+
+    twilio_response = MessagingResponse()
+    twilio_response.message(response)
+
+    return str(twilio_response)
+
+@app.route('/sms', methods=['POST'])
+def handle_sms():
+    incoming_message = request.form.get('Body', '').lower()
+    response, state = on_message([Message(content=incoming_message)], state=None)
+
+    twilio_response = MessagingResponse()
+    twilio_response.message(response)
+
+    return str(twilio_response)
+
+if __name__ == '__main__':
+    app.run(debug=True)


### PR DESCRIPTION
Mercor Chatbot Challenge 2.0:
Textbase Chatbot Challenge - Track 2: Open-source contributions/textbase Contribution:

This is a simplified example of integration of 3rd party libraries or API, like porting textbase over to a WhatsApp chatbot or a Twilio based SMS chatbot. With this code, the application can now handle both WhatsApp and SMS interactions using the Twilio API and respond with chatbot-generated responses based on the OpenAI GPT-3.5 Turbo model.

Requirements:
1. Install Twilio and Flask libraries
2. setting up accounts and configurations with Twilio and WhatsApp Business API