### PR TITLE
Fix Address already in use error

### DIFF
--- a/textbase/utils/server.py
+++ b/textbase/utils/server.py
@@ -5,6 +5,8 @@ from textbase.utils.download_build import download_and_extract_zip
 import click
 import urllib.parse
 
+socketserver.TCPServer.allow_reuse_address=True
+
 # URL of the zip file containing the dist folder
 zip_url = "https://storage.googleapis.com/chatbot_mainpy/build.zip"
 encoded_api_url = urllib.parse.quote("http://localhost:8080", safe='')


### PR DESCRIPTION
Contains the fix for `Python OSError: [Errno 98] Address already in use` when a user restarts the local server using the `test` command in a short period of time.