### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Response:
 ```bash
 Path to the main.py file: main.py #Type main.py here
 ```
+> If it not works : Copy the path of `main.py` from vs-code or just simply press `Shift+Alt+C` while being in `main.py` to copy its path and paste it above. 
+
 Now go to the link in blue color which is shown on the CLI and you will be able to chat with your bot!
 ![Local UI](assets/test_command.png)
 


### PR DESCRIPTION
## Scope
Documentation: How to paste path of `main.py` in response section.

### What was the Issue 
Response:
```bash
Path to the main.py file: main.py #Type main.py here
```
So if above is given as input we face error show in `before` .

### Solution

so instead of just writing  `main.py`, we have to give the complete path of the file , then only it is running .

Example:
```bash
Path to the main.py file: D:\github-repos\textbase\main.py
```

After this I got output as `After`

### Screenshots
- Before
![before](https://github.com/cofactoryai/textbase/assets/76617485/73a4f1fa-8ebf-4fc3-be3f-e953b39a6848)

- After
![after](https://github.com/cofactoryai/textbase/assets/76617485/6935266c-f04e-4c77-b662-44740d62850a)

---
## Code improvements
- I did not made any code changes ,
### Developer checklist
- [x] I’ve manually tested that code works locally on desktop and mobile browsers.
- [x] I’ve reviewed my code.
- [ ] I’ve removed all my personal credentials (API keys etc.) from the code.