### PR TITLE
Added Double Quotes in subprocess.Popen

### DIFF
--- a/textbase/textbase_cli.py
+++ b/textbase/textbase_cli.py
@@ -22,11 +22,11 @@ def test(path):
     server_path = importlib.resources.files('textbase').joinpath('utils', 'server.py')
     try:
         if os.name == 'posix':
-            process_local_ui = subprocess.Popen(f'python3 {server_path}', shell=True)
+            process_local_ui = subprocess.Popen(f'python3 "{server_path}"', shell=True)
         else:
-            process_local_ui = subprocess.Popen(f'python {server_path}', shell=True)
+            process_local_ui = subprocess.Popen(f'python "{server_path}"', shell=True)
 
-        process_gcp = subprocess.Popen(f'functions_framework --target=on_message --source={dir} --debug', 
+        process_gcp = subprocess.Popen(f'functions_framework --target=on_message --source="{dir}" --debug', 
                      shell=True,
                      stdin=subprocess.PIPE)
         process_local_ui.communicate()


### PR DESCRIPTION
## Scope
### Giving No such file or folder found error if there is any white space in the path like in user name
`Added Double Quotes in subprocess.Popen`



### Screenshots
![image](https://github.com/cofactoryai/textbase/assets/29832816/fa2273f7-583e-454e-98e4-76fa60382677)

---


### Developer checklist
- [x] I’ve manually tested that code works locally on desktop and mobile browsers.
- [X] I’ve reviewed my code.
- [X] I’ve removed all my personal credentials (API keys etc.) from the code.