### PR TITLE
feat url specific openai bot

### DIFF
--- a/docs/docs/examples/openai-url-specific-bot.md
+++ b/docs/docs/examples/openai-url-specific-bot.md
@@ -1,0 +1,75 @@
+---
+sidebar_position: 2
+---
+
+# Open AI URL specific guide bot
+
+This bot will be trained on the list of urls you provide and make API calls to OpenAI and processes the user input to answer url specific questions. It uses GPT-3.5 Turbo. It uses BeautifulSoup to extract text from the urls.
+
+from textbase import bot, Message
+from textbase.models import OpenAI
+from typing import List
+import requests
+from bs4 import BeautifulSoup
+
+# # Load your OpenAI API key
+
+OpenAI.api_key = ""
+urls = [] # Add list of URLs to train on
+
+def extract_text_from_urls(urls, max_words=1000):
+text_data = []
+
+    for url in urls:
+        try:
+            response = requests.get(url)
+            # Check if the request was successful (status code 200)
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.text, 'html.parser')
+                page_text = soup.get_text()
+                words = page_text.split()
+                truncated_text = ' '.join(words[:max_words])
+                text_data.append(truncated_text)
+            else:
+                print(
+                    f"Failed to fetch URL: {url}. Status code: {response.status_code}")
+        except Exception as e:
+            print(f"Error fetching URL: {url}. Error: {str(e)}")
+    return text_data
+
+# Prompt for GPT-3.5 Turbo
+
+SYSTEM_PROMPT = "This is the data for you to train. Questions will be asked on this - " + \
+ "\n".join(extract_text_from_urls(urls, max_words=1000))
+
+@bot()
+def on_message(message_history: List[Message], state: dict = None):
+
+    # Generate GPT-3.5 Turbo response
+    bot_response = OpenAI.generate(
+        system_prompt=SYSTEM_PROMPT,
+        message_history=message_history,  # Assuming history is the list of user messages
+        model="gpt-3.5-turbo",
+    )
+
+    response = {
+        "data": {
+            "messages": [
+                {
+                    "data_type": "STRING",
+                    "value": bot_response
+                }
+            ],
+            "state": state
+        },
+        "errors": [
+            {
+                "message": ""
+            }
+        ]
+    }
+
+    return {
+        "status_code": 200,
+        "response": response
+    }

--- a/examples/openai-url-specific-bot/main.py
+++ b/examples/openai-url-specific-bot/main.py
@@ -1,0 +1,67 @@
+from textbase import bot, Message
+from textbase.models import OpenAI
+from typing import List
+import requests
+from bs4 import BeautifulSoup
+
+# # Load your OpenAI API key
+OpenAI.api_key = ""
+urls = []  # Add list of URLs to train on
+
+def extract_text_from_urls(urls, max_words=1000):
+    text_data = []
+
+    for url in urls:
+        try:
+            response = requests.get(url)
+            # Check if the request was successful (status code 200)
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.text, 'html.parser')
+                page_text = soup.get_text()
+                words = page_text.split()
+                truncated_text = ' '.join(words[:max_words])
+                text_data.append(truncated_text)
+            else:
+                print(
+                    f"Failed to fetch URL: {url}. Status code: {response.status_code}")
+        except Exception as e:
+            print(f"Error fetching URL: {url}. Error: {str(e)}")
+    return text_data
+
+
+# Prompt for GPT-3.5 Turbo
+SYSTEM_PROMPT = "This is the data for you to train. Questions will be asked on this - " + \
+    "\n".join(extract_text_from_urls(urls, max_words=1000))
+
+
+@bot()
+def on_message(message_history: List[Message], state: dict = None):
+
+    # Generate GPT-3.5 Turbo response
+    bot_response = OpenAI.generate(
+        system_prompt=SYSTEM_PROMPT,
+        message_history=message_history,  # Assuming history is the list of user messages
+        model="gpt-3.5-turbo",
+    )
+
+    response = {
+        "data": {
+            "messages": [
+                {
+                    "data_type": "STRING",
+                    "value": bot_response
+                }
+            ],
+            "state": state
+        },
+        "errors": [
+            {
+                "message": ""
+            }
+        ]
+    }
+
+    return {
+        "status_code": 200,
+        "response": response
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ tabulate = "^0.9.0"
 functions-framework = "^3.4.0"
 yaspin = "^3.0.0"
 pydantic = "^2.3.0"
+bs4 = "^0.0.1"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Scope
`[The pull request includes an example of personalizing a chatbot to act as a guide for any web URL that allows web scraping. The example is contained in the main.py file, where you can add a list of URLs to train the chatbot.

The code uses the BeautifulSoup package to scrape data from the provided URLs in text format. Currently, it's limited to 1000 characters of text, but there's potential to expand this to scrape entire websites and create embeddings in the future.

The truncated text is used as the SYSTEM_PROMPT, and the chatbot is now capable of answering questions related to the provided URLs.]`



- [x] `[Sub task]`


### Screenshots
---


## Code improvements
- `[Did you add some generic like utility, component, or anything else useful outside of this PR]`


### Developer checklist
- [✓] I’ve manually tested that code works locally on desktop and mobile browsers.
- [✓] I’ve reviewed my code.
- [✓] I’ve removed all my personal credentials (API keys etc.) from the code.