### PR TITLE
Added a feature to openai-bot which allows it to return image urls.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ env.bak/
 venv.bak/
 cpcli-env/
 /poetry.lock
+.vscode
 
 # Spyder project settings
 .spyderproject

--- a/examples/openai-bot/main.py
+++ b/examples/openai-bot/main.py
@@ -3,7 +3,7 @@ from textbase.models import OpenAI
 from typing import List
 
 # Load your OpenAI API key
-OpenAI.api_key = "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"
+OpenAI.api_key = ""
 
 # Prompt for GPT-3.5 Turbo
 SYSTEM_PROMPT = """You are chatting with an AI. There are no specific prefixes for responses, so you can ask or talk about anything you like.

--- a/examples/openai-bot/main.py
+++ b/examples/openai-bot/main.py
@@ -3,7 +3,7 @@ from textbase.models import OpenAI
 from typing import List
 
 # Load your OpenAI API key
-OpenAI.api_key = ""
+OpenAI.api_key = "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"
 
 # Prompt for GPT-3.5 Turbo
 SYSTEM_PROMPT = """You are chatting with an AI. There are no specific prefixes for responses, so you can ask or talk about anything you like.
@@ -14,12 +14,25 @@ pleasant chat!
 @bot()
 def on_message(message_history: List[Message], state: dict = None):
 
+    prompt_check = ['photo','image','picture']
+    flag = 0
+    print(message_history)
     # Generate GPT-3.5 Turbo response
-    bot_response = OpenAI.generate(
-        system_prompt=SYSTEM_PROMPT,
-        message_history=message_history, # Assuming history is the list of user messages
-        model="gpt-3.5-turbo",
-    )
+    for prompt in prompt_check:
+        if prompt in message_history[len(message_history)-1]['content'][0]['value']:
+            flag = 1
+            bot_response = OpenAI.image_generate(
+            system_prompt=SYSTEM_PROMPT,
+            message_history=message_history, # Assuming history is the list of user messages
+            model="gpt-3.5-turbo",
+            )
+            break
+    if flag != 1:
+        bot_response = OpenAI.generate(
+            system_prompt=SYSTEM_PROMPT,
+            message_history=message_history, # Assuming history is the list of user messages
+            model="gpt-3.5-turbo",
+        )
 
     response = {
         "data": {

--- a/textbase/models.py
+++ b/textbase/models.py
@@ -49,6 +49,7 @@ class OpenAI:
             if contents:
                 filtered_messages.extend(contents)
 
+
         response = openai.ChatCompletion.create(
             model=model,
             messages=[
@@ -63,6 +64,26 @@ class OpenAI:
         )
 
         return response["choices"][0]["message"]["content"]
+    
+    @classmethod
+    def image_generate(
+        cls,
+        system_prompt: str,
+        message_history: list[Message],
+        model="gpt-3.5-turbo",
+        max_tokens=3000,
+        temperature=0.7,
+    ):
+        assert cls.api_key is not None, "OpenAI API key is not set."
+        openai.api_key = cls.api_key
+
+        response = openai.Image.create(
+            prompt = message_history[len(message_history)-1]['content'][0]['value'],
+            )
+        message_history.clear()
+        image_url = response['data'][0]['url']
+
+        return image_url
 
 class HuggingFace:
     api_key = None


### PR DESCRIPTION
## Scope
The original openai-bot only replied with text, the new implemented feature allows the bot to now return image urls for specific prompts.


### Screenshots

![image](https://github.com/cofactoryai/textbase/assets/42542851/c5c3757f-51b2-4ab3-81ac-5c165320b36a)
Response before implementation of the feature.

![image](https://github.com/cofactoryai/textbase/assets/42542851/03eccb54-2d7b-412e-bb30-e922596643f8)
Response after implementation of the feature.

## Code improvements
- Utilised the Image generation API endpoint to implement the feature.


### Developer checklist
- [ ✓ ] I’ve manually tested that code works locally on desktop and mobile browsers.
- [ ✓ ] I’ve reviewed my code.
- [ ✓ ] I’ve removed all my personal credentials (API keys etc.) from the code.