### PR TITLE
Feat: Add Support for Google Palm AI API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ tabulate = "^0.9.0"
 functions-framework = "^3.4.0"
 yaspin = "^3.0.0"
 pydantic = "^2.3.0"
+google-generativeai = "^0.1.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/textbase/models.py
+++ b/textbase/models.py
@@ -6,6 +6,7 @@ import typing
 import traceback
 
 from textbase import Message
+import google.generativeai as palm
 
 # Return list of values of content.
 def get_contents(message: Message, data_type: str):
@@ -144,3 +145,39 @@ class BotLibre:
         message = data['message']
 
         return message
+
+class PalmAI:
+    api_key = None
+    response = None
+    client = None
+
+    @classmethod
+    def generate(
+        cls,
+        system_prompt: str,
+        message_history: list[Message],
+        model="models/chat-bison-001",
+        examples: typing.List[typing.Tuple] = None,
+        temperature = 0.7,
+    ):
+        assert cls.api_key is not None, "PalmAI API key is not set."
+        if cls.client == None:
+            palm.configure(api_key=cls.api_key)
+            cls.client = palm
+
+        most_recent_message = get_contents(message_history[-1], "STRING")[0]["content"]
+
+        if cls.response == None:
+            cls.response = cls.client.chat(
+                context = system_prompt,
+                model = model,
+                temperature=temperature,
+                messages=most_recent_message
+            )
+        
+        else:
+            cls.response = cls.response.reply(
+                message=most_recent_message
+            )
+
+        return cls.response.last


### PR DESCRIPTION
## Scope
- Add Support for the Google's Palm AI with through Palm API.
- Adding support for it it crucial, as it provides access to `chat-bison` - It is an LLM model that is specifically trained for chat purposes
- No need to do any hacky method of passing context as message history.
- Google Palm API natively supports `create chat` and `reply chat`


### Screenshots
<img width="503" alt="image" src="https://github.com/cofactoryai/textbase/assets/89455838/ebdff404-5daa-4510-a342-317129cf9c86">



### Developer checklist
- [x] I’ve manually tested that code works locally on desktop and mobile browsers.
- [x] I’ve reviewed my code.
- [x] I’ve removed all my personal credentials (API keys etc.) from the code.