### PR TITLE
Update README: Fix Broken Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Since it is just Python you can use whatever models, libraries, vector databases
 
 Coming soon:
 - [x] [PyPI package](https://pypi.org/project/textbase-client/)
-- [x] Easy web deployment via [textbase deploy](docs/docs/deployment/deploy-from-cli.md)
+- [x] Easy web deployment via [textbase-client deploy](docs/docs/deployment/deploy-from-cli.md)
 - [ ] SMS integration
 - [ ] Native integration of other models (Claude, Llama, ...)
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Since it is just Python you can use whatever models, libraries, vector databases
 
 Coming soon:
 - [x] [PyPI package](https://pypi.org/project/textbase-client/)
-- [x] Easy web deployment via [textbase deploy](/docs/deployment/deploy-from-cli)
+- [x] Easy web deployment via [textbase deploy](docs/docs/deployment/deploy-from-cli.md)
 - [ ] SMS integration
 - [ ] Native integration of other models (Claude, Llama, ...)
 


### PR DESCRIPTION
**Pull Request Message:**

This pull request addresses a broken link in the README file. The "Easy web deployment via [textbase deploy](/docs/deployment/deploy-from-cli)" link was leading to a 404 error page due to an incorrect path. 

**Changes Made:**
- Updated the link to "Easy web deployment via [textbase deploy](/docs/docs/deployment/deploy-from-cli.md)" to fix the broken URL.

This change ensures that users can access the deployment documentation without encountering any issues.

**Related Issue:** None

**Reviewer(s):** Please review and merge.

Thank you!