### PR TITLE
add download command to download zip file uploaded by user

### DIFF
--- a/textbase/textbase_cli.py
+++ b/textbase/textbase_cli.py
@@ -289,6 +289,30 @@ def logs(bot_name, api_key, start_time):
     fetch_and_display_logs(cloud_url=cloud_url, 
                            headers=headers, 
                            params=params)    
+    
+    
+@cli.command()
+@click.option("--bot_name", prompt="Name of the bot", required=True)
+@click.option("--api_key", prompt="Textbase API Key", required=True)
+def download(bot_name, api_key):
+    cloud_url = f"{CLOUD_URL}/downloadZip"
+    headers = {
+        "Authorization": f"Bearer {api_key}"
+    }
+
+    params = {"botName": bot_name}
+    response = requests.get(cloud_url, 
+                            headers=headers, 
+                            params=params, 
+                            stream=True)
+
+    if response.status_code == 200:
+        with open(f"{bot_name}.zip", "wb") as f:
+            for chunk in response.iter_content(chunk_size=1024):
+                if chunk:
+                    f.write(chunk)
+    else:
+        click.echo(click.style(f"Error: {response.status_code}, {response.text}", fg="red"))
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
## What does this PR do?

On running the `download` command it downloads the zip of the corresponding bot in the root directory.
<img width="941" alt="Screenshot 2023-09-11 at 3 25 19 PM" src="https://github.com/cofactoryai/textbase/assets/139532137/1f6b014b-7bcd-435c-8abc-598fc39fa8d9">
<img width="243" alt="Screenshot 2023-09-11 at 3 25 33 PM" src="https://github.com/cofactoryai/textbase/assets/139532137/2b8cd0ad-9ff0-4643-bee6-b9b401de7a80">
