### PR TITLE
print real err message in logs if something wrong happens

### DIFF
--- a/textbase/utils/logs.py
+++ b/textbase/utils/logs.py
@@ -4,6 +4,7 @@ from rich.table import Table
 from rich.text import Text
 import time
 import click
+import json
 from yaspin import yaspin
 
 def fetch_and_display_logs(cloud_url, headers, params):
@@ -36,7 +37,8 @@ def fetch_and_display_logs(cloud_url, headers, params):
                 else:
                     click.echo(click.style("No logs found in the response.", fg='yellow'))
             else:
-                click.echo(click.style("Failed to retrieve logs.", fg='red'))
+                error_message = json.loads(response.text)
+                click.echo(click.style(f"Failed to retrieve logs ❌ \n Error: {error_message['message']}, Details: {error_message['error']}", fg='red'))
 
             # Poll the endpoint every 3 seconds
             time.sleep(3)


### PR DESCRIPTION
## What does this PR do?

- if lets say the user asks for logs of the bot which does not exist, it prints the real error message for that instead of just `Failed to retrieve logs`
<img width="860" alt="Screenshot 2023-09-20 at 6 35 15 PM" src="https://github.com/cofactoryai/textbase/assets/139532137/9c572ed4-0e52-4e62-a558-33e495b0e788">
